### PR TITLE
fix(css): scope Tailwind source detection to src

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,12 @@
 @import url("https://fonts.googleapis.com/css?family=Shadows+Into+Light");
 @import url("https://fonts.googleapis.com/css2?family=Borel&display=swap");
 @import url("https://fonts.googleapis.com/css?family=Ubuntu");
-@import "tailwindcss";
+/* source(none) apaga la deteccion automatica de fuentes. Sin esto Tailwind
+   escanea todo el proyecto salvo lo ignorado por git, incluidos .github,
+   package.json y pnpm-lock.yaml, y compila cualquier palabra que coincida
+   con el nombre de un utility. Las clases solo viven en src. */
+@import "tailwindcss" source(none);
+@source "./**/*.{js,jsx}";
 
 @theme {
   /* Colores personalizados */


### PR DESCRIPTION
Found while chasing a 30 byte CSS difference between branches during the PR audit. It is not a size problem, it is a correctness problem.

## The problem

`src/index.css` imported Tailwind with no source configuration:

```css
@import "tailwindcss";
```

Tailwind v4 automatic source detection then scans the whole project minus gitignored paths. That includes `.github/`, `package.json`, `pnpm-lock.yaml` and `README.md`. Any bare word in those files that matches a utility name gets compiled into the production bundle.

This was already happening. Building the branch for #75 emitted a rule master does not have:

```css
.contents{display:contents}
```

It comes from the `permissions` block of the workflow YAML:

```yaml
permissions:
  contents: write
```

Editing a GitHub Actions file changed the CSS served to users, with no change anywhere in `src/`.

## Why tailwind.config.js did not already prevent this

```js
content: ["./src/**/*.{js,jsx,ts,tsx}"]
```

That looks like it covers the case, but Tailwind v4 does not load a JS config unless the CSS asks for it with `@config`, and `index.css` never does. The scope it describes was never in effect.

The colours in that file are duplicated in the `@theme` block of `index.css`, which is what actually renders them. So `tailwind.config.js` is inert. Left in place here since deleting it is a separate decision, but it is dead and worth removing.

## Changes

| File | Change |
|------|--------|
| `src/index.css` | `@import "tailwindcss" source(none);` plus an explicit `@source "./**/*.{js,jsx}"` |

`source(none)` is the part that actually disables auto-detection. Adding `@source` on its own does not.

Scoping to `src/` only is safe here: `index.html` and `public/index.html` contain no `class` attributes, so every class name in the project lives under `src/`.

## Test plan

- [x] Built master and this branch, extracted every emitted selector and compared: **0 utilities removed, 0 added**
- [x] Same output content hash as master (`index-C_9jX4Wj.css`, 12.26 kB)
- [x] Regression test: dropped the #75 workflow YAML into the tree and rebuilt. Output CSS byte-identical, `.contents` rule absent. Leak prevented.
- [x] `pnpm run build` succeeds

## Related

Third of three PRs from the audit, alongside #75 (CI and Dependabot config) and #76 (unused dependencies and the inert `pnpm.overrides` block). No file overlap between them.